### PR TITLE
Fix bug: Ticking a box unticks previous questions

### DIFF
--- a/Questionare/questions/static/radio_buttons.js
+++ b/Questionare/questions/static/radio_buttons.js
@@ -1,6 +1,6 @@
 $(function () {
   $(".chb").change(function() {
-      $(".chb").prop('checked', false);
+      $(this).siblings().filter('.chb').prop('checked', false);
       $(this).prop('checked', true);
   });
 });

--- a/Questionare/questions/templates/questions/Questionare.html
+++ b/Questionare/questions/templates/questions/Questionare.html
@@ -37,7 +37,7 @@ background-color:MediumSeaGreen;
         {% if question.type == "radio" %}
           <input type="checkbox" class="chb" name={{question.name}} value="{{choice.name}}">{{choice.name}}<br/>
         {% elif question.type == "text" %}
-          <textarea class="form-control" name={{question.name}}" placeholder="{{choice.name}}"></textarea>
+          <textarea class="form-control" name={{question.name}} placeholder="{{choice.name}}"></textarea>
         {% endif %}
       {% endfor %}
     </p>


### PR DESCRIPTION
Previously, ticking a box on one question would untick the user's answer to all previous questions. 